### PR TITLE
Add support for PS5 DualSense and Xbox Series X controllers; bump to 2.1.1

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,12 +1,13 @@
 diff --git a/gui/re.chiaki.Chiaki.appdata.xml b/gui/re.chiaki.Chiaki.appdata.xml
-index adb10ba..4793648 100644
+index adb10ba..8c635d0 100644
 --- a/gui/re.chiaki.Chiaki.appdata.xml
 +++ b/gui/re.chiaki.Chiaki.appdata.xml
-@@ -22,4 +22,8 @@
+@@ -22,4 +22,9 @@
    </screenshots>
    <update_contact>chiaki@metallic.software</update_contact>
    <content_rating type="oars-1.1" />
 +  <releases>
++    <release date="2021-01-24" version="2.1.1" />
 +    <release date="2021-01-15" version="2.1.0" />
 +    <release date="2020-12-29" version="2.0.1" />
 +  </releases>

--- a/re.chiaki.Chiaki.yaml
+++ b/re.chiaki.Chiaki.yaml
@@ -88,6 +88,25 @@ modules:
         url: https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz
         sha256: 84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
 
+  - name: SDL2
+    config-opts:
+      - --enable-sdl-dlopen
+      - --disable-arts
+      - --disable-esd
+      - --disable-nas
+      - --disable-alsa
+      - --disable-oss
+      - --disable-sndio
+      - --disable-libudev
+      - --enable-video-wayland
+      - --enable-wayland-shared=no
+      - --enable-video-kmsdrm
+      - --disable-rpath
+    sources:
+      - type: git
+        url: https://github.com/libsdl-org/SDL.git
+        commit: 4cd981609b50ed273d80c635c1ca4c1e5518fb21
+
   - name: chiaki
     buildsystem: cmake
     builddir: true

--- a/re.chiaki.Chiaki.yaml
+++ b/re.chiaki.Chiaki.yaml
@@ -113,8 +113,8 @@ modules:
     sources:
       - type: git
         url: https://git.sr.ht/~thestr4ng3r/chiaki
-        tag: v2.1.0
-        commit: fcdc414692b33ecae1f30a19dc4cd81d4bd77121
+        tag: v2.1.1
+        commit: be9e5eb616fdf8870573d25232a7f2303b02d94a
       - type: patch
         path: appdata.patch
     post-install:


### PR DESCRIPTION
SDL 2.0.14 introduces support for PS5 DualSense and Xbox Series X controllers, among others.

2.0.14 will be included in org.freedesktop.Sdk 21.08, so when a new version of org.kde.Platform comes out that depends on it, we can stop bundling it explicitly. Until then, it's the only way to support modern controllers. It is ABI compatible with 2.0.12, which is what is currently bundled by default.