### PR TITLE
Revert "Fixing some Wayland issues"

### DIFF
--- a/re.chiaki.Chiaki.yaml
+++ b/re.chiaki.Chiaki.yaml
@@ -14,8 +14,7 @@ separate-locales: false
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
   - --device=all
   - --allow=bluetooth
   - --socket=pulseaudio


### PR DESCRIPTION
Under wayland chiaki seems to go black in fullscreen for some users, so let's err on the side of safety and default to X11 again.

We'll reconsider this in a year.

This reverts commit a72c2206d1aa8d9e623ba4b69502b5dc8c733146.

Closes #8