### PR TITLE
[beta] Update to chiaki master

### DIFF
--- a/re.chiaki.Chiaki.yaml
+++ b/re.chiaki.Chiaki.yaml
@@ -85,8 +85,8 @@ modules:
     sources:
       - type: git
         url: https://git.sr.ht/~thestr4ng3r/chiaki
-        tag: v2.1.1
-        commit: be9e5eb616fdf8870573d25232a7f2303b02d94a
+        branch: master
+        commit: 4c8209762c1f822d2066367062170f47692abd54
       - type: patch
         path: appdata.patch
     post-install:


### PR DESCRIPTION
This commit includes some important changes to controller handling which should add support for other controllers beyond the standard PS4 controller.

See https://git.sr.ht/~thestr4ng3r/chiaki/commit/4c8209762c1f822d2066367062170f47692abd54

See #13 