### PR TITLE
Update to version 2.2.0

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,12 +1,13 @@
 diff --git a/gui/re.chiaki.Chiaki.appdata.xml b/gui/re.chiaki.Chiaki.appdata.xml
-index adb10ba..8c635d0 100644
+index adb10ba..36b89c2 100644
 --- a/gui/re.chiaki.Chiaki.appdata.xml
 +++ b/gui/re.chiaki.Chiaki.appdata.xml
-@@ -22,4 +22,9 @@
+@@ -22,4 +22,10 @@
    </screenshots>
    <update_contact>chiaki@metallic.software</update_contact>
    <content_rating type="oars-1.1" />
 +  <releases>
++    <release date="2023-08-20" version="2.2.0" />
 +    <release date="2021-01-24" version="2.1.1" />
 +    <release date="2021-01-15" version="2.1.0" />
 +    <release date="2020-12-29" version="2.0.1" />

--- a/re.chiaki.Chiaki.yaml
+++ b/re.chiaki.Chiaki.yaml
@@ -31,7 +31,7 @@ modules:
   - name: protobuf-compilers
     sources:
       - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-cpp-3.21.12.tar.gz
+        url: https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz
         sha256: 4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460
 
   - name: python3-google
@@ -84,8 +84,8 @@ modules:
     sources:
       - type: git
         url: https://git.sr.ht/~thestr4ng3r/chiaki
-        tag: v2.1.1
-        commit: be9e5eb616fdf8870573d25232a7f2303b02d94a
+        tag: v2.2.0
+        commit: 89368f63c99d67cde8868c0269b66a1b0c507397
       - type: patch
         path: appdata.patch
     post-install:


### PR DESCRIPTION
Hi, :wave: 

Besides the update to Chiaki release, I had to fix the protobuf-cpp URL. The next release is v22 and it has [breaking changes to CPP](https://github.com/protocolbuffers/protobuf/releases/tag/v22.0), so I thought it was better to not touch it.

The appdata patch was also updated.